### PR TITLE
東京の天気を取得するAPI実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
-# test0603
+# Tokyo Weather API
+
+This project implements an API to fetch weather data for Tokyo using OpenWeatherMap API.
+
+## Architecture
+
+The API is built using the following AWS services:
+
+- **API Gateway**: Provides the REST API endpoint
+- **Lambda**: Handles the business logic for fetching weather data
+- **Systems Manager Parameter Store**: Securely stores the OpenWeatherMap API key
+- **DynamoDB**: Caches weather data to reduce API calls to OpenWeatherMap
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────────────┐
+│  API        │     │  Lambda     │     │  OpenWeatherMap     │
+│  Gateway    │────▶│  Function   │────▶│  API                │
+└─────────────┘     └─────────────┘     └─────────────────────┘
+                          │
+                          │
+                    ┌─────▼─────┐     ┌─────────────┐
+                    │  SSM      │     │  DynamoDB   │
+                    │  Param    │     │  (キャッシュ) │
+                    │  Store    │     │             │
+                    └───────────┘     └─────────────┘
+```
+
+## API Endpoints
+
+- `GET /weather` - Returns the current weather for Tokyo
+- `GET /tokyo` - Alternative endpoint that also returns Tokyo weather
+
+## Deployment Instructions
+
+1. **Prerequisites**:
+   - Get an API key from [OpenWeatherMap](https://openweathermap.org/api)
+   - Configure AWS CLI with appropriate credentials
+
+2. **Deploy the stack**:
+   ```
+   npm run build
+   cdk deploy TokyoWeatherApiStack
+   ```
+
+3. **Set the API key**:
+   After deployment, update the SSM parameter with your actual OpenWeatherMap API key:
+   ```
+   aws ssm put-parameter --name "/tokyo-weather-api/openweathermap-api-key" --type "SecureString" --value "YOUR_API_KEY" --overwrite
+   ```
+
+## Testing the API
+
+After deployment, you can test the API using curl:
+
+```
+curl https://[your-api-id].execute-api.[region].amazonaws.com/prod/weather
+```
+
+Or using the Tokyo-specific endpoint:
+
+```
+curl https://[your-api-id].execute-api.[region].amazonaws.com/prod/tokyo
+```
+
+## Caching Strategy
+
+The API implements a caching strategy to reduce calls to the OpenWeatherMap API:
+
+- Weather data is cached in DynamoDB for 1 hour (configurable)
+- If cached data exists and is not expired, it will be returned
+- If no cache exists or it's expired, fresh data will be fetched from OpenWeatherMap
+
+## Error Handling
+
+The API implements proper error handling for:
+- Failed API key retrieval
+- OpenWeatherMap API failures
+- Cache retrieval/storage failures

--- a/bin/a.ts
+++ b/bin/a.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { AStack } from '../lib/a-stack';
+import { TokyoWeatherApiStack } from '../lib/tokyo-weather-api-stack';
 
 const app = new cdk.App();
 new AStack(app, 'AStack');
+new TokyoWeatherApiStack(app, 'TokyoWeatherApiStack');

--- a/lib/lambda/tokyo-weather/index.ts
+++ b/lib/lambda/tokyo-weather/index.ts
@@ -1,0 +1,182 @@
+import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import axios from 'axios';
+
+// Initialize clients
+const ssmClient = new SSMClient();
+const ddbClient = new DynamoDBClient();
+const ddbDocClient = DynamoDBDocumentClient.from(ddbClient);
+
+// Environment variables
+const SSM_PARAM_NAME = process.env.SSM_PARAM_NAME || '';
+const CACHE_TABLE_NAME = process.env.CACHE_TABLE_NAME || '';
+const CACHE_TTL_SECONDS = parseInt(process.env.CACHE_TTL_SECONDS || '3600', 10);
+const TOKYO_CITY_ID = process.env.TOKYO_CITY_ID || '1850147'; // Tokyo city ID
+
+/**
+ * Get OpenWeatherMap API key from SSM Parameter Store
+ */
+async function getApiKey(): Promise<string> {
+  try {
+    const response = await ssmClient.send(
+      new GetParameterCommand({
+        Name: SSM_PARAM_NAME,
+        WithDecryption: true,
+      })
+    );
+    return response.Parameter?.Value || '';
+  } catch (error) {
+    console.error('Error retrieving API key from SSM:', error);
+    throw new Error('Failed to retrieve API key');
+  }
+}
+
+/**
+ * Check if we have cached weather data
+ */
+async function getWeatherFromCache(cityId: string): Promise<any | null> {
+  try {
+    const response = await ddbDocClient.send(
+      new GetCommand({
+        TableName: CACHE_TABLE_NAME,
+        Key: { cityId },
+      })
+    );
+
+    // Check if we have a valid cache entry
+    if (response.Item) {
+      // Check if cache is still valid
+      if (response.Item.ttl && response.Item.ttl > Math.floor(Date.now() / 1000)) {
+        console.log('Cache hit for city:', cityId);
+        return response.Item.weatherData;
+      }
+      console.log('Cache expired for city:', cityId);
+    } else {
+      console.log('No cache found for city:', cityId);
+    }
+    return null;
+  } catch (error) {
+    console.error('Error retrieving from cache:', error);
+    return null; // Continue with API call on cache error
+  }
+}
+
+/**
+ * Store weather data in cache
+ */
+async function storeWeatherInCache(cityId: string, weatherData: any): Promise<void> {
+  try {
+    const ttl = Math.floor(Date.now() / 1000) + CACHE_TTL_SECONDS;
+    
+    await ddbDocClient.send(
+      new PutCommand({
+        TableName: CACHE_TABLE_NAME,
+        Item: {
+          cityId,
+          weatherData,
+          ttl,
+          timestamp: new Date().toISOString(),
+        },
+      })
+    );
+    console.log('Weather data cached for city:', cityId);
+  } catch (error) {
+    console.error('Error storing in cache:', error);
+    // Continue even if caching fails
+  }
+}
+
+/**
+ * Fetch weather data from OpenWeatherMap API
+ */
+async function fetchWeatherFromApi(apiKey: string, cityId: string): Promise<any> {
+  try {
+    const url = `https://api.openweathermap.org/data/2.5/weather?id=${cityId}&appid=${apiKey}&units=metric`;
+    const response = await axios.get(url);
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching weather data from API:', error);
+    throw new Error('Failed to fetch weather data from OpenWeatherMap');
+  }
+}
+
+/**
+ * Format the weather data for response
+ */
+function formatWeatherData(data: any): any {
+  return {
+    city: data.name,
+    country: data.sys.country,
+    weather: {
+      description: data.weather[0].description,
+      temperature: data.main.temp,
+      feels_like: data.main.feels_like,
+      humidity: data.main.humidity,
+      pressure: data.main.pressure,
+      wind: {
+        speed: data.wind.speed,
+        direction: data.wind.deg,
+      },
+    },
+    timestamp: new Date().toISOString(),
+    source: data.cached ? 'cache' : 'api',
+  };
+}
+
+/**
+ * Lambda handler function
+ */
+export const handler = async (event: any): Promise<any> => {
+  console.log('Event:', JSON.stringify(event));
+  
+  try {
+    // Use Tokyo city ID by default
+    const cityId = TOKYO_CITY_ID;
+    
+    // Try to get weather data from cache first
+    let weatherData = await getWeatherFromCache(cityId);
+    let source = 'cache';
+    
+    // If not in cache or expired, fetch from API
+    if (!weatherData) {
+      const apiKey = await getApiKey();
+      weatherData = await fetchWeatherFromApi(apiKey, cityId);
+      source = 'api';
+      
+      // Store in cache for future requests
+      await storeWeatherInCache(cityId, weatherData);
+    }
+    
+    // Add source information to the weather data
+    weatherData.cached = source === 'cache';
+    
+    // Format the response
+    const formattedData = formatWeatherData(weatherData);
+    
+    // Return successful response
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*', // CORS header
+      },
+      body: JSON.stringify(formattedData),
+    };
+  } catch (error: any) {
+    console.error('Error:', error);
+    
+    // Return error response
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*', // CORS header
+      },
+      body: JSON.stringify({
+        message: 'Error fetching weather data',
+        error: error.message,
+      }),
+    };
+  }
+};

--- a/lib/lambda/tokyo-weather/package.json
+++ b/lib/lambda/tokyo-weather/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "tokyo-weather-lambda",
+  "version": "1.0.0",
+  "description": "Lambda function to fetch Tokyo weather data",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "@aws-sdk/client-ssm": "^3.0.0",
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0",
+    "axios": "^1.6.0"
+  }
+}

--- a/lib/tokyo-weather-api-stack.ts
+++ b/lib/tokyo-weather-api-stack.ts
@@ -1,0 +1,79 @@
+import { Duration, Stack, StackProps } from 'aws-cdk-lib';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as path from 'path';
+import { Construct } from 'constructs';
+
+export class TokyoWeatherApiStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    // Create SSM Parameter for OpenWeatherMap API key
+    // Note: The actual API key will be set manually after deployment
+    const apiKeyParam = new ssm.StringParameter(this, 'OpenWeatherMapApiKey', {
+      parameterName: '/tokyo-weather-api/openweathermap-api-key',
+      stringValue: 'dummy-value-to-be-updated-after-deployment',
+      description: 'API Key for OpenWeatherMap',
+      type: ssm.ParameterType.SECURE_STRING,
+    });
+
+    // Create DynamoDB table for caching weather data
+    const weatherCacheTable = new dynamodb.Table(this, 'WeatherCache', {
+      partitionKey: { name: 'cityId', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: 'ttl', // TTL for cache expiration
+      removalPolicy: props?.env?.account === 'production' 
+        ? undefined  // Keep the default in production
+        : undefined, // In non-production, you might want to use DESTROY
+    });
+
+    // Create Lambda function for fetching weather data
+    const weatherFunction = new lambda.Function(this, 'TokyoWeatherFunction', {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, 'lambda/tokyo-weather')),
+      timeout: Duration.seconds(10),
+      environment: {
+        SSM_PARAM_NAME: apiKeyParam.parameterName,
+        CACHE_TABLE_NAME: weatherCacheTable.tableName,
+        CACHE_TTL_SECONDS: '3600', // 1 hour cache
+        TOKYO_CITY_ID: '1850147', // OpenWeatherMap city ID for Tokyo
+      },
+    });
+
+    // Grant Lambda function permissions to read from SSM Parameter Store
+    apiKeyParam.grantRead(weatherFunction);
+
+    // Grant Lambda function permissions to read/write to DynamoDB
+    weatherCacheTable.grantReadWriteData(weatherFunction);
+
+    // Create API Gateway
+    const api = new apigateway.RestApi(this, 'TokyoWeatherApi', {
+      restApiName: 'Tokyo Weather API',
+      description: 'API to fetch weather data for Tokyo',
+      deployOptions: {
+        stageName: 'prod',
+      },
+      // Enable CORS
+      defaultCorsPreflightOptions: {
+        allowOrigins: apigateway.Cors.ALL_ORIGINS,
+        allowMethods: apigateway.Cors.ALL_METHODS,
+      },
+    });
+
+    // Create API resource and method
+    const weatherResource = api.root.addResource('weather');
+    weatherResource.addMethod('GET', new apigateway.LambdaIntegration(weatherFunction), {
+      apiKeyRequired: false, // Set to true if you want to require API key
+    });
+
+    // Add a specific Tokyo endpoint for clarity
+    const tokyoResource = api.root.addResource('tokyo');
+    tokyoResource.addMethod('GET', new apigateway.LambdaIntegration(weatherFunction), {
+      apiKeyRequired: false,
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "tokyo-weather-api",
   "version": "0.1.0",
   "bin": {
     "a": "bin/a.js"
@@ -20,7 +20,11 @@
     "typescript": "~5.6.3"
   },
   "dependencies": {
+    "@aws-sdk/client-ssm": "^3.0.0",
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0",
     "aws-cdk-lib": "2.198.0",
+    "axios": "^1.6.0",
     "constructs": "^10.0.0"
   }
 }


### PR DESCRIPTION
## 概要
OpenWeatherMap APIを利用して東京の天気情報を取得するAPIを実装しました。

## 実装内容
- API Gateway、Lambda、SSM Parameter Store、DynamoDBを使用したサーバーレスアーキテクチャ
- OpenWeatherMap APIからの天気データ取得
- DynamoDBを使用したキャッシュ機能（1時間）
- エラーハンドリングとCORS対応

## アーキテクチャ
```
┌─────────────┐     ┌─────────────┐     ┌─────────────────────┐
│  API        │     │  Lambda     │     │  OpenWeatherMap     │
│  Gateway    │────▶│  Function   │────▶│  API                │
└─────────────┘     └─────────────┘     └─────────────────────┘
                          │
                          │
                    ┌─────▼─────┐     ┌─────────────┐
                    │  SSM      │     │  DynamoDB   │
                    │  Param    │     │  (キャッシュ) │
                    │  Store    │     │             │
                    └───────────┘     └─────────────┘
```

## APIエンドポイント
- `GET /weather` - 東京の現在の天気を返す
- `GET /tokyo` - 同じく東京の天気を返す代替エンドポイント

## デプロイ後の設定
デプロイ後、SSM Parameter Storeに実際のOpenWeatherMap APIキーを設定する必要があります：
```
aws ssm put-parameter --name "/tokyo-weather-api/openweathermap-api-key" --type "SecureString" --value "YOUR_API_KEY" --overwrite
```

Closes #1